### PR TITLE
refactor: remove retry_strategy string in favor of strategy object wi…

### DIFF
--- a/src/bitrix24_client/async_client.py
+++ b/src/bitrix24_client/async_client.py
@@ -105,7 +105,7 @@ class AsyncBitrix24Client(BaseBitrix24Client):
                     if response.status_code == 503:
                         if retries == self._max_retries:
                             raise Bitrix24Error(f"Max retries exceeded for 503 error: {url}")
-                        delay = self._calculate_delay(retries)
+                        delay = self._retry_strategy.calculate_delay(retries)
                         await asyncio.sleep(delay)
                         retries += 1
                         continue

--- a/src/bitrix24_client/retry_strategies/__init__.py
+++ b/src/bitrix24_client/retry_strategies/__init__.py
@@ -1,0 +1,6 @@
+from .exponential import ExponentialRetryStrategyI
+
+
+__all__ = {
+    'ExponentialRetryStrategyI'
+}

--- a/src/bitrix24_client/retry_strategies/exponential.py
+++ b/src/bitrix24_client/retry_strategies/exponential.py
@@ -1,0 +1,11 @@
+from .interfaces import RetryStrategyI
+
+
+class ExponentialRetryStrategyI(RetryStrategyI):
+    def __init__(self, base: float, max_delay: float):
+        self.base = base
+        self.max_delay = max_delay
+
+    def calculate_delay(self, retries: int) -> float:
+        delay = self.base * (2 ** (retries - 1))
+        return min(delay, self.max_delay)

--- a/src/bitrix24_client/retry_strategies/exponential_jitter.py
+++ b/src/bitrix24_client/retry_strategies/exponential_jitter.py
@@ -1,0 +1,14 @@
+from random import uniform
+
+from .interfaces import RetryStrategyI
+
+
+class ExponentialJitterRetryStrategyI(RetryStrategyI):
+    def __init__(self, base: float, max_delay: float):
+        self.base = base
+        self.max_delay = max_delay
+
+    def calculate_delay(self, retries: int) -> float:
+        exp_delay = self.base * (2 ** (retries - 1))
+        delay = uniform(0, exp_delay)
+        return min(delay, self.max_delay)

--- a/src/bitrix24_client/retry_strategies/fixed.py
+++ b/src/bitrix24_client/retry_strategies/fixed.py
@@ -1,0 +1,10 @@
+from .interfaces import RetryStrategyI
+
+
+class FixedRetryStrategyI(RetryStrategyI):
+    def __init__(self, base: float, max_delay: float):
+        self.base = base
+        self.max_delay = max_delay
+
+    def calculate_delay(self, retries: int) -> float:
+        return min(self.base, self.max_delay)

--- a/src/bitrix24_client/retry_strategies/interfaces.py
+++ b/src/bitrix24_client/retry_strategies/interfaces.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+
+class RetryStrategyI(ABC):
+    @abstractmethod
+    def calculate_delay(self, retries: int) -> float:
+        """
+        Calculate delay in seconds before the next retry.
+
+        Args:
+            retries (int): The current retry attempt number (starting from 1).
+
+        Returns:
+            float: Delay in seconds.
+        """
+        raise NotImplementedError

--- a/src/bitrix24_client/retry_strategies/linear.py
+++ b/src/bitrix24_client/retry_strategies/linear.py
@@ -1,0 +1,11 @@
+from .interfaces import RetryStrategyI
+
+
+class LinearRetryStrategyI(RetryStrategyI):
+    def __init__(self, base: float, max_delay: float):
+        self.base = base
+        self.max_delay = max_delay
+
+    def calculate_delay(self, retries: int) -> float:
+        delay = self.base * retries if retries > 0 else self.base
+        return min(delay, self.max_delay)

--- a/src/bitrix24_client/retry_strategies/logarithmic.py
+++ b/src/bitrix24_client/retry_strategies/logarithmic.py
@@ -1,0 +1,13 @@
+from math import log1p
+
+from .interfaces import RetryStrategyI
+
+
+class LogarithmicRetryStrategyI(RetryStrategyI):
+    def __init__(self, base: float, max_delay: float):
+        self.base = base
+        self.max_delay = max_delay
+
+    def calculate_delay(self, retries: int) -> float:
+        delay = self.base * log1p(retries) if retries > 0 else self.base
+        return min(delay, self.max_delay)

--- a/src/bitrix24_client/sync_client.py
+++ b/src/bitrix24_client/sync_client.py
@@ -98,7 +98,7 @@ class Bitrix24Client(BaseBitrix24Client):
                 if response.status_code == 503:
                     if retries == self._max_retries:
                         raise Bitrix24Error(f"Max retries exceeded for 503 error: {url}")
-                    delay = self._calculate_delay(retries)
+                    delay = self._retry_strategy.calculate_delay(retries)
                     time.sleep(delay)
                     retries += 1
                     continue


### PR DESCRIPTION
…th default

- Removed string-based `retry_strategy` parameter from BaseBitrix24Client
- Introduced strategy object injection via `RetryStrategyI` interface
- Default retry strategy is now `ExponentialRetryStrategy`
- Enables easy extension with custom retry strategies without modifying core code